### PR TITLE
Add README Documentation for Shared Packages

### DIFF
--- a/packages/constants/ReadME.md
+++ b/packages/constants/ReadME.md
@@ -1,0 +1,239 @@
+This package provides global constants shared across the Nextra Templates ecosystem.  
+These constants ensure that metadata, structured data, social previews, and site configuration remain consistent across packages such as `@nextra-templates/utils` and `@nextra-templates/ui`.
+
+---
+## Overview
+
+The constants exported from this package define:
+
+- Base site information
+- Open Graph defaults
+- Default metadata values
+- Owner / author information
+
+These values are often used when generating metadata, SEO configurations, and structured data.
+
+## Installation
+
+This package is primarily used inside the monorepo but can be installed independently:
+
+```bash
+pnpm add @nextra-templates/constants
+OR 
+npm install @nextra-templates/constants
+```
+
+## Available Constants
+
+Below is a detailed explanation of each constant exported by the package
+## SITE_URL
+The base URL of your site. Used for generating canonical URLs, social sharing links, and constructing absolute URLs throughout the application.
+
+- Type: string
+- Default: 'http://localhost:3000'
+
+Example:
+```bash
+export const SITE_URL = 'http://localhost:3000';
+```
+## SITE_NAME
+The official name of your website. Used in page titles, Open Graph metadata, and branding across the site.
+- Type: string
+- Default: 'Name of Site'
+
+Example:
+```bash
+ export const SITE_NAME = 'Name of Site';
+ ```
+
+## DEFAULT_OG_IMAGE
+Default Open Graph image URL used for social media sharing when a page-specific image isn't provided. Typically points to your site logo or a branded image.
+
+- Type: string
+- Constructed from: ${SITE_URL}/favicon
+
+Example:
+```bash
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/favicon`;
+  // Resolves to: 'http://localhost:3000/favicon'
+```
+## Owner Information
+Details about the site owner or author:
+```bash
+import { OWNER_NAME, OWNER_JOB } from '@nextra-templates/constants';
+```
+
+## OWNER_NAME
+The name of the site owner or primary author. Used in author metadata, schema markup, and footer information.
+
+- Type: string
+- Default: 'Owner Name'
+
+Example:
+```bash
+export const OWNER_NAME = 'Owner Name';
+```
+
+## OWNER_JOB
+The job title or professional role of the site owner. Used in author schema markup and about sections.
+
+- Type: string
+- Default: 'Owner Job'
+
+Example:
+```bash
+export const OWNER_JOB = 'Owner Job';
+```
+
+## Usage Examples: A. Using in Metadata
+```bash
+import { SITE_NAME, SITE_URL, DEFAULT_OG_IMAGE } from '@nextra-templates/constants';
+
+export const metadata = {
+  title: SITE_NAME,
+  description: 'Welcome to my site',
+  openGraph: {
+    type: 'website',
+    url: SITE_URL,
+    title: SITE_NAME,
+    image: DEFAULT_OG_IMAGE
+  },
+  twitter: {
+    card: 'summary_large_image',
+    image: DEFAULT_OG_IMAGE
+  }
+};
+```
+
+## Usage Examples: B. Using in Schema Markup
+```bash
+import { OWNER_NAME, OWNER_JOB, SITE_NAME } from '@nextra-templates/constants';
+
+export function getPersonSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: OWNER_NAME,
+    jobTitle: OWNER_JOB,
+    worksFor: {
+      '@type': 'Organization',
+      name: SITE_NAME
+    }
+  };
+}
+```
+
+## Usage Examples: C. Using in  Components
+```bash
+import { SITE_NAME, OWNER_NAME } from '@nextra-templates/constants';
+
+export function Footer() {
+  const currentYear = new Date().getFullYear();
+  
+  return (
+    <footer>
+      <p>© {currentYear} {SITE_NAME}. All rights reserved.</p>
+      <p>Created by {OWNER_NAME}</p>
+    </footer>
+  );
+}
+```
+
+## Usage Examples: D. Using in Canonical URLs
+```bash
+import { SITE_URL } from '@nextra-templates/constants';
+
+export function getCanonicalUrl(slug) {
+  return `${SITE_URL}/${slug}`;
+  // Example: 'http://localhost:3000/docs/getting-started'
+}
+```
+## Imports
+All constants can be imported from the root of the package::
+```bash
+import {
+  SITE_URL,
+  SITE_NAME,
+  DEFAULT_OG_IMAGE,
+  OWNER_NAME,
+  OWNER_JOB
+} from '@nextra-templates/constants';
+```
+
+## Best Practices
+- Keep it DRY — Use constants instead of hardcoded values throughout your application
+- Compose constants — Build complex values from simpler constants (like DEFAULT_OG_IMAGE from SITE_URL)
+- Document purpose — Add comments explaining why each constant exists
+- Use environment variables — For deployment-specific values
+- Update in one place — Changes automatically propagate throughout the monorepo
+- TypeScript support — Leverage type safety with TypeScript
+
+## Adding New Constants
+When adding new constants to this package:
+
+- Define the constant in src/index.ts
+- Add JSDoc comments explaining its purpose and usage
+- Include the type annotation
+- Update this README with the new constant
+
+## Integration with Other Packages
+With @nextra-templates/utils
+Constants are used by utility functions to generate metadata:
+```bash
+import { getBaseMetadata } from '@nextra-templates/utils';
+import { SITE_NAME, DEFAULT_OG_IMAGE } from '@nextra-templates/constants';
+// Base metadata uses constants for defaults
+const baseMetadata = getBaseMetadata();
+```
+
+## With @nextra-templates/ui
+Constants can be used to style components consistently:
+
+```bash
+import { Container } from '@nextra-templates/ui';
+import { SITE_NAME } from '@nextra-templates/constants';
+
+export function Header() {
+  return (
+    <Container>
+      <h1>{SITE_NAME}</h1>
+    </Container>
+  );
+}
+```
+
+## TypeScript
+All constants are fully typed and provide IDE autocomplete:
+
+```bash
+const siteUrl: string = SITE_URL;
+const siteName: string = SITE_NAME;
+const ownerName: string = OWNER_NAME;
+```
+## Contributing
+When modifying constants:
+
+1. Update the constant value in src/index.ts
+2. Add or update JSDoc comments
+3. Update examples in this README if the usage pattern changed
+4. Test that dependent packages work correctly with the updated constants
+5. Run npm run build or yarn run build to ensure TypeScript compilation succeeds
+
+## Project Structure
+
+constants/
+├── src/
+│   └── index.ts          # All exported constants
+├── tsconfig.json         # TypeScript configuration
+├── package.json          # Package metadata
+├── README.md             # This file
+└── dist/                 # Compiled output (generated)
+## Quick Reference
+| Constant | Type | Purpose |
+| :------ | :---------: | -----: |
+| SITE_URL | String |Base URL for canonical links and routing|
+| SITE_NAME | String | Official site name for branding |
+| DEFAULT_OG_IMAGE | String | Social sharing image |
+| OWNER_NAME | String | Site owner/author name |
+| OWNER_JOB | String | Site owner's job title |
+

--- a/packages/utils/ReadME.md
+++ b/packages/utils/ReadME.md
@@ -1,0 +1,161 @@
+# @nextra-templates/utils
+
+This package provides class name merging, text transformation, metadata generation, and structured data schema builders.
+
+## Features
+
+- Class Name Merging — Safely merge and deduplicate class names with Tailwind CSS support
+- Text Transformation — Convert text to URL-friendly slugs
+- Metadata Helpers — Generate SEO-optimized metadata for pages
+- Structured Data Schemas — Build Schema.org JSON-LD for rich search results
+
+
+## Installation
+
+This package is intended to be consumed inside the monorepo, but if installed independently it works like any other workspace dependency.
+
+```bash
+pnpm add @nextra-templates/utils
+```
+Use this for yarn
+
+
+```bash
+npm install @nextra-templates/utils
+```
+Use this for Npm
+
+## Class Name Helper - cn(...inputs)
+This class name helper merges class names in a safe and predictable way using clsx and tailwind-smart-merge. This prevents conflicting Tailwind classes and simplifies conditional styling.
+
+Example:
+
+```bash
+import { cn } from '@nextra-templates/utils';
+
+const buttonClass = cn(
+  'px-4 py-2 rounded',
+  isActive && 'bg-blue-600 text-white',
+  disabled && 'opacity-50 cursor-not-allowed'
+);
+```
+
+## Text Transformation: slugify(text)
+This transforms a string into a clean URL-friendly slug.
+It lowercases text, trims spaces, replaces punctuation, and removes unsupported characters.
+Example:
+```bash
+import { slugify } from '@nextra-templates/utils';
+
+slugify('Hello World!'); 
+// it returns: "hello-world"
+```
+
+## Metadata Helpers
+
+These helpers simplify creating metadata objects for Next.js pages. They rely on shared constants from @nextra-templates/constants. Example of these metadata helpers are:
+
+##getBaseMetadata()
+
+Returns default metadata for the site, including Open Graph data, preview images, Twitter metadata, and canonical URLs.
+
+```bash
+import { getBaseMetadata } from '@nextra-templates/utils';
+
+const metadata = getBaseMetadata();
+// Returns base metadata configuration
+```
+
+## getPageMetadata(options)
+Builds a complete metadata object for a specific page. It merges the default metadata with page-specific fields like title, description, keywords, canonical URL, and social images.
+
+## Parameters:
+
+- title (string) — Page title
+- description (string) — Page description
+- slug (string) — Page URL slug
+- tags (string[]) — SEO keywords/tags
+- ogImage (string, optional) — Open Graph image URL
+
+```bash
+import { getPageMetadata } from '@nextra-templates/utils';
+
+export const metadata = getPageMetadata({
+  title: 'Documentation',
+  description: 'A guide to using the template',
+  slug: 'docs',
+  tags: ['docs', 'guide'],
+  ogImage: 'https://example.com/og-image.png'
+});
+```
+
+## Structured Data Schema Helpers
+These functions generate structured data in the Schema.org format. They can be included in metadata or injected into pages as JSON-LD.
+
+## getPersonSchema()
+Defines schema data representing the site owner as a person, including name, job title, social profiles, and organization information.
+
+```bash
+import { getPersonSchema } from '@nextra-templates/utils';
+
+const personSchema = getPersonSchema();
+```
+
+## getWebsiteSchema()
+Creates schema data for the website including basic site information and search actions.
+```bash
+import { getWebsiteSchema } from '@nextra-templates/utils';
+
+const websiteSchema = getWebsiteSchema();
+```
+
+## getBreadcrumbSchema(items)
+
+Creates a BreadcrumbList schema from an array of navigation items, each with a name and URL.
+```bash
+import { getBreadcrumbSchema } from '@nextra-templates/utils';
+
+const breadcrumbs = getBreadcrumbSchema([
+  { name: 'Home', url: '/' },
+  { name: 'Docs', url: '/docs' },
+]);
+```
+
+## Imports
+```bash
+Import helpers directly from the package root:
+import {
+  cn,
+  slugify,
+  getBaseMetadata,
+  getPageMetadata,
+  getPersonSchema,
+  getWebsiteSchema,
+  getBreadcrumbSchema
+} from '@nextra-templates/utils';
+```
+Internal modules are also available for more granular imports
+```bash
+import { cn } from '@nextra-templates/utils/classes';
+import { getBaseMetadata } from '@nextra-templates/utils/metadata';
+import { getPersonSchema } from '@nextra-templates/utils/structured-data-schema';
+```
+## Internal Modules
+
+- ./classes — Class name utilities and type definitions
+- ./metadata — Metadata generation and helpers
+- ./structured-data-schema — Schema.org builder functions
+
+## Contributing
+When adding new utilities to this package, ensure they:
+
+1. Have clear, concise documentation
+2. Include TypeScript types
+3. Have accompanying examples
+4. Are re-exported from the package root
+5. Are tested before merging
+
+
+
+
+ 


### PR DESCRIPTION
This pull request adds clear and structured README files for the shared internal packages in the monorepo. The goal is to improve discoverability, make the purpose of each package easier to understand, and provide guidance for future contributors.

**A. Included Changes @nextra-templates/utils**

- Added detailed README explaining all available helpers:
-  cn class name utility
-  slugify text helper
-  metadata helpers (getBaseMetadata, getPageMetadata)
-  structured data helpers (getPersonSchema, getWebsiteSchema, getBreadcrumbSchema)
-  Included usage examples and import paths
-  Added an overview and human-readable descriptions for each helper

**B. Included Changes @nextra-templates/constants**

Added README describing all exposed constants:

- SITE_URL
-  SITE_NAME
-  DEFAULT_OG_IMAGE
-  OWNER_NAME
-  OWNER_JOB
-  Documented their purpose and how they integrate with other packages

### Why This Matters

- Improves clarity for new contributors
-  Ensures all shared packages have proper documentation
-  Supports onboarding and long-term maintainability
-  Aligns with the project’s documentation standards